### PR TITLE
feat(random-ingress-operator): add value to configure controller arguments

### DIFF
--- a/charts/random-ingress-operator/templates/deployment.yaml
+++ b/charts/random-ingress-operator/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           command:
           - "/manager"
           args:
-            - "--leader-elect"
+            {{- toYaml .Values.controller.args | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/random-ingress-operator/values.yaml
+++ b/charts/random-ingress-operator/values.yaml
@@ -13,6 +13,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+controller:
+  args:
+    - "--leader-election"
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
The operator does not currently accept a Configmap, so being able to provide
command line arguments is useful to configure it.